### PR TITLE
feat: allow optional subnet integration for flex function app

### DIFF
--- a/.changes/unreleased/Added-20260414-114631.yaml
+++ b/.changes/unreleased/Added-20260414-114631.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Allow optionally setting `virtual_network_subnet_id` for flex function apps.
+time: 2026-04-14T11:46:31.50149+02:00

--- a/functionapp_flex.tf
+++ b/functionapp_flex.tf
@@ -23,10 +23,11 @@ resource "azurerm_function_app_flex_consumption" "this" {
   storage_authentication_type = "StorageAccountConnectionString"
   storage_access_key          = data.azurerm_storage_account.artifacts.primary_access_key
 
-  runtime_name           = var.runtime
-  runtime_version        = var.runtime_version
-  maximum_instance_count = var.app_scale_limit
-  instance_memory_in_mb  = var.memory
+  runtime_name              = var.runtime
+  runtime_version           = var.runtime_version
+  maximum_instance_count    = var.app_scale_limit
+  instance_memory_in_mb     = var.memory
+  virtual_network_subnet_id = var.virtual_network_subnet_id
 
   app_settings = merge({
     APPINSIGHTS_INSTRUMENTATIONKEY = azurerm_application_insights.primary.instrumentation_key

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,9 @@ variable "service_plan_sku_name" {
   type        = string
   default     = "Y1"
 }
+
+variable "virtual_network_subnet_id" {
+  description = "The ID of the subnet to integrate the flex function app with"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary
- add optional module input `virtual_network_subnet_id` (default `null`)
- wire `virtual_network_subnet_id = var.virtual_network_subnet_id` into the flex function app resource
- add changie fragment for this addition

## Notes
- change applies to flex hosting only, as the other function app setup is deprecated and we shouldn't encourage staying on it.
